### PR TITLE
Add character bbox and mask outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ synthtiger -o results -w 4 -v examples/synthtiger/template.py SynthTiger example
 synthtiger -o results -w 4 -v examples/synthtiger/template.py SynthTiger examples/synthtiger/config_vertical.yaml
 ```
 
-<img src="https://user-images.githubusercontent.com/12423224/153699084-1d5fbb15-0ca0-4a85-9639-6f2c4c1bf9ec.png" width="50%"/>
+<p>
+    <img src="https://user-images.githubusercontent.com/12423224/153699084-1d5fbb15-0ca0-4a85-9639-6f2c4c1bf9ec.png" width="50%"/>
+    <img src="https://user-images.githubusercontent.com/12423224/189514683-af06812a-7a23-49fc-b2b2-297f072c3f06.png" width="25%"/>
+</p>
 
 #### Multiline text images
 

--- a/examples/synthtiger/template.py
+++ b/examples/synthtiger/template.py
@@ -196,13 +196,9 @@ class SynthTiger(templates.Template):
 
         self.color.apply([text_layer], color)
         self.texture.apply([text_layer])
-        self.style.apply([text_layer], style)
-        self.style.apply(char_layers, style)
-        self.transform.apply([text_layer], transform)
-        self.transform.apply([mask_layer], transform)
-        self.transform.apply(char_layers, transform)
-        self.fit.apply([text_layer])
-        self.fit.apply(char_layers)
+        self.style.apply([text_layer, *char_layers], style)
+        self.transform.apply([text_layer, mask_layer, *char_layers], transform)
+        self.fit.apply([text_layer, *char_layers])
         self.pad.apply([text_layer])
 
         for char_layer in char_layers:

--- a/examples/synthtiger/template.py
+++ b/examples/synthtiger/template.py
@@ -119,7 +119,7 @@ class SynthTiger(templates.Template):
         image = _blend_images(
             fg_image, bg_image, visibility_check=self.visibility_check
         )
-        image = self._postprocess_image(image)
+        image, mask = self._postprocess_image(image, mask)
 
         data = {
             "image": image,
@@ -255,11 +255,13 @@ class SynthTiger(templates.Template):
         out = layer.output()
         return out
 
-    def _postprocess_image(self, image):
+    def _postprocess_image(self, image, mask):
         layer = layers.Layer(image)
-        self.postprocess.apply([layer])
+        mask_layer = layers.Layer(mask)
+        self.postprocess.apply([layer, mask_layer])
         out = layer.output()
-        return out
+        mask = mask_layer.output()
+        return out, mask
 
 
 def _blend_images(src, dst, blend_mode=None, visibility_check=False):


### PR DESCRIPTION
## Description

Add character bbox and mask outputs.
Character bbox data is in `coord.txt` file and mask data is in `masks` directory.
The format of `coord.txt` is `<image_path>\t<bbox>\t<bbox>\t<bbox>...`. (`<bbox>`=`<xmin>,<ymin>,<xmax>,<ymax>`)
Same post-processing was applied to both text image and mask image.

<img src="https://user-images.githubusercontent.com/12423224/189515998-1e5956de-b8ba-4bee-b857-d56d1253bd2b.png" width="40%"/>

Related issues
- https://github.com/clovaai/synthtiger/issues/8
- https://github.com/clovaai/synthtiger/issues/3

## Changes in this PR

- Added character bbox and mask outputs in synthtiger template.
- Refactored synthtiger template.

## How has this been tested?

Checked directly whether images are generated correctly.
