### PR TITLE
Deprecated font.getsize() is replaced with font.getmask()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "imgaug",
         "numpy",
         "opencv-python",
-        "pillow>=8.2.0",
+        "pillow==10.3.0",
         "pygame",
         "python-bidi",
         "pytweening",

--- a/synthtiger/layers/text_layer.py
+++ b/synthtiger/layers/text_layer.py
@@ -172,11 +172,11 @@ class TextLayer(Layer):
 
         if not vertical:
             ascent, descent = font.getmetrics()
-            width = font.getsize(text, direction=direction)[0]
+            width = font.getmask(text, direction=direction).size[0]
             height = ascent + descent
             bbox = [0, -ascent, width, height]
         else:
-            width, height = font.getsize(text, direction=direction)
+            width,height = font.getmask(text, direction=direction).size
             bbox = [-width // 2, 0, width, height]
 
         return bbox


### PR DESCRIPTION
## Description

`font.getsize()` function was deprecated from v9 onwards. Since `Pillow>=10`, this function does not exist. Ubuntu 24.04 LTS supports python 3.12 which forces Pillow version upgrade to >10 . Therefore changed the deprecated functions to use the correct Pillow functions.

- Related issues:
  -  Encountered while working on my project

## Changes in this PR
 
- Refactored `getsize()` to use `getmask()` method 

## How has this been tested?

I have tested the new implementation for my project and it is working. I did not see any test cases that I update. Let me know if any other test cases need to be updated.
